### PR TITLE
allow adminOrderId to be null in UserLineItems

### DIFF
--- a/backend/src/migrations/20251114202427-userLineItems-adminOrderId-allowNull.js
+++ b/backend/src/migrations/20251114202427-userLineItems-adminOrderId-allowNull.js
@@ -7,11 +7,36 @@ module.exports = {
       type: Sequelize.UUID,
       allowNull: true,
     });
+    await queryInterface.changeColumn("UserLineItems", "basePrice", {
+      type: Sequelize.DECIMAL(10,2),
+      allowNull: true,
+    });
+    await queryInterface.changeColumn("UserLineItems", "percentOff", {
+      type: Sequelize.DECIMAL(5,2),
+      allowNull: true,
+    });
+    await queryInterface.changeColumn("UserLineItems", "finalPrice", {
+      type: Sequelize.DECIMAL(10,2),
+      allowNull: true,
+    });
   },
 
   async down (queryInterface, Sequelize) {
    await queryInterface.changeColumn("UserLineItems", "adminOrderId", {
       type: Sequelize.UUID,
+      allowNull: false,
+    });
+    await queryInterface.changeColumn("UserLineItems", "basePrice", {
+      type: Sequelize.DECIMAL(10,2),
+      allowNull: false,
+    });
+    await queryInterface.changeColumn("UserLineItems", "percentOff", {
+      type: Sequelize.DECIMAL(5,2),
+      allowNull: false,
+      defaultValue: 0.0
+    });
+    await queryInterface.changeColumn("UserLineItems", "finalPrice", {
+      type: Sequelize.DECIMAL(10,2),
       allowNull: false,
     });
   }

--- a/backend/src/models/UserLineItem.js
+++ b/backend/src/models/UserLineItem.js
@@ -23,16 +23,15 @@ module.exports = (sequelize, DataTypes) => {
       },
       basePrice: {
         type: DataTypes.DECIMAL(10, 2),
-        allowNull: false,
+        allowNull: true,
       },
       percentOff: {
         type: DataTypes.DECIMAL(5, 2),
-        allowNull: false,
-        defaultValue: 0.0,
+        allowNull: true,
       },
       finalPrice: {
         type: DataTypes.DECIMAL(10, 2),
-        allowNull: false,
+        allowNull: true,
       },
       adminOrderId: {
         type: DataTypes.UUID,


### PR DESCRIPTION
The other tables that have the adminOrderId will only have rows entered if we have an adminOrderId to enter, so we only need to set adminOrderId:allowNulls=true in UserLineItems